### PR TITLE
Clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ To remove the maintenance message, empty the `content/maintenance.md` file.
 
 
 ## Release Notes
-Release notes will always be shown to users when the [`content/release-notes.md`](https://github.com/instana/ui-notifications/blob/gh-pages/content/release-notes.md) file is changed. You can use markdown in this file and there is no document size restriction. If you want to use links in the release notes file, you can do so. Just make sure that you use absolute links instead of relative ones. For instance, in order to reference a file `pic.png` which is located in the `content/files/` directory, use the link `/notifications/files/pic.png`.
+Release notes for a specific release number will be shown to users via the respective file identified by its release number in [`content/release-notes/`](https://github.com/instana/ui-notifications/blob/gh-pages/content/release-notes/). Also ensure that you add a new entry for your new file in [`content/release-notes/index.json`](https://github.com/instana/ui-notifications/blob/gh-pages/content/release-notes/index.json).
 
+You can use markdown in this file and there is no document size restriction. If you want to use links in the release notes file, you can do so. Just make sure that you use absolute links instead of relative ones. For instance, in order to reference a file `pic.png` which is located in the `content/files/` directory, use the link `/notifications/files/pic.png`.
 
 ## Contributing
 


### PR DESCRIPTION
### What

This PR contains 2 main changes:

1. Add a `Contributing` section to the main README to clarify things to watch out for/ensure when adding new release/maintenance notes. We've broken release notes for customers more than once, so hopefully this will help reduce that frequency, and also help others to troubleshoot when it does happen.
2. Reword the `Release Notes` section on the README as I believe the top level `/content/release-notes.md` file is deprecated and not used anymore? And we probably can remove the file as well?


### Why

While troubleshooting missing release notes a few weeks ago on SoW duty, it was not that straightforward to figure out what went wrong in the few minutes I had to spend on it before needing to move on to another Customer ticket.

Some things one may say are "straightforward", but I would rather be explicit and leave as little as possible to assumptions, imagination, sheer investigative prowess etc 😄.

I'd like to also encourage us to document our repositories a little bit more with certain "standard" (for our definition of standard) sections e.g. `Local Development Setup`, `Testing`, `Deployment`, etc.