### PR TITLE
INSTA-75448: clear mizu and teal maintenance notices

### DIFF
--- a/content/maintenance/mizu.md
+++ b/content/maintenance/mizu.md
@@ -1,2 +1,1 @@
-On *Wednesday, 2026-02-25*, we will roll out release-314.
-Rollout for APAC customers is scheduled to start at *11:30 AM* UTC!
+

--- a/content/maintenance/teal.md
+++ b/content/maintenance/teal.md
@@ -1,2 +1,1 @@
-On *Wednesday, 2026-02-25*, we will roll out release-314.
-Rollout for APAC customers is scheduled to start at *11:30 AM* UTC!
+


### PR DESCRIPTION
One of the RE tasks is to check if the rollout notifications have been removed from maintenance/<env>.md file, see: https://ibm.ent.box.com/notes/2129404388884#g-lqyaosyn