### PR TITLE
Update release notes for AWS SDK for Java 2.x support

### DIFF
--- a/content/release-notes/1.317.md
+++ b/content/release-notes/1.317.md
@@ -63,6 +63,10 @@ You can now search and retrieve ingestion data beyond the first 10 results in da
 
 Smart alerts now support alerting on entity count.
 
+### Support for AWS SDK for Java 2.x
+
+Instana now supports AWS SDK for Java 2.x. It will replace AWS SDK for Java 1.x in the future. For timeline details, see [Deprecated features](https://www.ibm.com/docs/en/instana-observability/current?topic=notes-deprecated-removed-features).
+
 
 ## Fixes
 


### PR DESCRIPTION
Added support for AWS SDK for Java 2.x in release notes.