### PR TITLE
Adding OpenTelemetry Service correlation feature mention for release-319

### DIFF
--- a/content/release-notes/1.319.md
+++ b/content/release-notes/1.319.md
@@ -32,6 +32,10 @@ Instana now supports infrastructure correlation for calls to remotely monitored 
 
 Improved the rendering of general span semantic attributes in call details.
 
+### OpenTelemetry Log Service Correlation
+
+Added support for OpenTelemetry Log Service Correlation where the OpenTelemetry Collector [configures the "k8sattributes" processor to collect the "service.name" attribute](../../../pages/ecosystem/opentelemetry/k8s-openshift-log-collection.md).
+
 ## Fixes
 
 The following issues are fixed in release 1.0.319:

--- a/content/release-notes/1.319.md
+++ b/content/release-notes/1.319.md
@@ -28,13 +28,13 @@ You can now filter calls from a website or mobile application on the "Analytics"
 
 Instana now supports infrastructure correlation for calls to remotely monitored Microsoft SQL Server databases. For successful correlation, the calls must use a host or cluster name that uniquely matches the name reported from the database infrastructure entity.
 
+### OpenTelemetry log service correlation
+
+Added support for OpenTelemetry log service correlation where the OpenTelemetry Collector [configures the `k8sattributes` processor to collect the `service.name` attribute](../../../pages/ecosystem/opentelemetry/k8s-openshift-log-collection.md). For more information, see [Correlating OpenTelemetry logs to services](../../ecosystem/opentelemetry/opentelemetry_log_service_correlation.md).
+
 ### OpenTelemetry traces
 
 Improved the rendering of general span semantic attributes in call details.
-
-### OpenTelemetry Log Service Correlation
-
-Added support for OpenTelemetry Log Service Correlation where the OpenTelemetry Collector [configures the "k8sattributes" processor to collect the "service.name" attribute](../../../pages/ecosystem/opentelemetry/k8s-openshift-log-collection.md).
 
 ## Fixes
 


### PR DESCRIPTION
WHY

As part of `release-319`, OpenTelemetry Log message correlation with [Services](https://www.ibm.com/docs/en/instana-observability?topic=applications-services) has been added.

WHAT

Adding missing reference to this capability to the `release-319` release notes.